### PR TITLE
fix(cookiecutter): don't render layout.html

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,8 @@
   "pkg_name": "{{ cookiecutter.project_slug|replace('-', '_') }}",
   "description": "A short description of this project",
   "version": "0.0.0",
-  "package_requirements": "Type any packages required, leaving spaces in between each name. Press enter if none."
+  "package_requirements": "Type any packages required, leaving spaces in between each name. Press enter if none.",
+  "_copy_without_render": [
+    "docs/_templates/layout.html"
+  ]
 }


### PR DESCRIPTION
Cookiecutter was failing because the Jinja template of layout.html was conflicting with the
variables of cookiecutter. Cookiecutter uses Jinja templating to render the project variables into
template files. Because layout.html also used Jinja it was confusing cookiecutter with tons of
variables it did not have knowledge of. Long story short, if you add more jinja files that you don't
want to be hydrated with variables you can add it to the `_copy_without_render` list in
`cookiecutter.json`.

Fixes #14